### PR TITLE
Add macOS ARM64 (Apple Silicon) support

### DIFF
--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '16'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- None
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- arm64-apple-darwin20.0.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '16'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- None
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- arm64-apple-darwin20.0.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '16'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- None
+cuda_compiler_version:
+- None
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '16'
+macos_machine:
+- arm64-apple-darwin20.0.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,5 @@ github:
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
+build_platform:
+  osx_arm64: osx_64

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     - numpy >=1.19                           # [build_platform != target_platform]
     - swig <4.1                              # [build_platform != target_platform]
     - openmm >=8.0.0                         # [build_platform != target_platform]
-    - {{ stdlib("c") }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }}  # [cuda_compiler_version not in (undefined, 'None')]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - numpy >=1.19                           # [build_platform != target_platform]
     - swig <4.1                              # [build_platform != target_platform]
     - openmm >=8.0.0                         # [build_platform != target_platform]
+    - {{ stdlib("c") }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }}  # [cuda_compiler_version not in (undefined, 'None')]
@@ -43,6 +44,7 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
     - swig <4.1
     - openmm >=8.0.0
     - ocl-icd  # [linux]


### PR DESCRIPTION
This PR adds support for building the openmm-nonbonded-slicing package on macOS ARM64 (Apple Silicon) machines.

## Changes Made

- **Add cross-compilation support**: Modified `conda-forge.yml` to enable building ARM64 packages using Intel builders via `build_platform: osx_arm64: osx-64`
- **Create ARM64 CI configurations**: Added CI configuration files for Python 3.10, 3.11, and 3.12 on ARM64
- **Update deployment target**: Set macOS deployment target to 11.0 (minimum required for ARM64)
- **Configure target platform**: Set appropriate target_platform and machine type for ARM64

## Background

Currently, the package is only available for:
- ✅ Linux x86_64 (CPU + CUDA variants)  
- ✅ macOS Intel x86_64 (CPU-only)
- ❌ macOS Apple Silicon ARM64 (missing)
- ❌ Windows (intentionally unsupported)

This PR addresses the missing ARM64 support, which will allow conda users on Apple Silicon Macs to install the package directly instead of building from source or using Rosetta 2 emulation.

## Testing

The conda-forge CI will automatically test these configurations once the PR is merged. The builds should work since:
1. The meta.yaml recipe doesn't explicitly exclude ARM64 for CPU-only builds
2. OpenMM and other dependencies are available for ARM64
3. Cross-compilation from osx-64 to osx-arm64 is supported by conda-forge

## Notes

- These changes only add **CPU-only builds** for ARM64 (CUDA builds remain Intel-only, as expected)
- The recipe already includes the necessary cross-compilation setup
- No changes to the source code or build scripts were needed

This PR replaces the previous #8 which was incorrectly created from a branch in the main repository instead of a fork.