### PR TITLE
Fix Python 3.9+ setuptools compatibility issue

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - numpy >=1.19                           # [build_platform != target_platform]
     - swig <4.1                              # [build_platform != target_platform]
     - openmm >=8.0.0                         # [build_platform != target_platform]
+    - setuptools >=65.5.1,<69                # [build_platform != target_platform]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }}  # [cuda_compiler_version not in (undefined, 'None')]
@@ -43,6 +44,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools >=65.5.1,<69
+    - wheel
     - swig <4.1
     - openmm >=8.0.0
     - ocl-icd  # [linux]


### PR DESCRIPTION
## 🛠️ **Fix: Python 3.9+ Build Failures**

This PR resolves the setuptools compatibility issue that was causing build failures for Python 3.9 and later versions.

### 🔴 **Problem**
Builds for Python 3.9+ were failing with:
```
TypeError: 'NoneType' object is not subscriptable (key slice(None, None, None))
in setuptools/_distutils/compilers/C/unix.py line 290
```

This error occurred during the wheel building phase when the distutils linker configuration was `None`.

### ✅ **Solution**

1. **Pin setuptools version**: Added `setuptools >=65.5.1,<69` to both build and host requirements
2. **Add wheel dependency**: Explicitly included `wheel` in host requirements for proper wheel building
3. **Cross-compilation consistency**: Added setuptools to build requirements for cross-compilation scenarios

### 🧪 **Expected Results**

After this fix:
- ✅ Python 3.9, 3.10, 3.11, and 3.12 builds should succeed
- ✅ PyPy 3.9 builds should succeed
- ✅ All platforms (Linux, macOS) should build successfully
- ✅ Both CPU-only and CUDA variants should work

### 📋 **Changes Made**

```yaml
requirements:
  build:
    # ... existing dependencies ...
    - setuptools >=65.5.1,<69                # [build_platform != target_platform]
  host:
    - python
    - pip
    - setuptools >=65.5.1,<69
    - wheel
    - swig <4.1
    # ... rest of dependencies ...
```

### 🔗 **Related Issues**

This addresses the root cause of build failures identified in PR #9 (ARM64 support). Once this is merged, the ARM64 support PR should also succeed.

### 🎯 **Testing**

The setuptools version range `>=65.5.1,<69` is specifically chosen to:
- Include fixes for Python 3.9+ compatibility
- Avoid newer versions that have known issues with distutils
- Maintain compatibility with conda-forge build infrastructure